### PR TITLE
Use custom replacements for filtered patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Custom replacements for filter patterns.
+
 
 ## [1.3.0] - 2021-06-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ defmodule ClientFormatterImpl do
   @derive {
     MetaLogger.Formatter,
     formatter_fn: &__MODULE__.format/1,
-    filter_patterns: [~s("email":".*")]
+    filter_patterns: [
+      {~s/"name":".*"/, ~s/"name":"[FILTERED]"/},
+      "very_secret_word"
+    ]
   }
 
   def build(payload) do
@@ -115,7 +118,7 @@ http_request
 ### Options
 
 * `:formatter_fn` (required) - The function which is used to format a given payload. The function must return a string or a list of strings.
-* `:filter_patterns` (optional) - Regex patterns which will be used to replace sensitive information in a payload.
+* `:filter_patterns` (optional) - Regex patterns which will be used to replace sensitive information in a payload. It is a list of strings or tuples (can be mixed). If tuples are given, the first element is used as a regex pattern to match, and the second is as a replacement which will be used to replace it, e.g. `{~s/"name": ".+"/, ~s/"name": "[FILTERED]"/}`.
 
 ## Release
 

--- a/lib/meta_logger/formatter.ex
+++ b/lib/meta_logger/formatter.ex
@@ -27,7 +27,7 @@ defimpl MetaLogger.Formatter, for: Any do
 
     quote do
       defimpl MetaLogger.Formatter, for: unquote(module) do
-        @replacement "[FILTERED]"
+        @default_replacement "[FILTERED]"
 
         def format(struct) do
           formatter_fn = Keyword.fetch!(unquote(options), :formatter_fn)
@@ -48,8 +48,12 @@ defimpl MetaLogger.Formatter, for: Any do
         end
 
         defp filter(patterns, payload) do
-          Enum.reduce(patterns, payload, fn pattern, payload ->
-            String.replace(payload, ~r/#{pattern}/, @replacement)
+          Enum.reduce(patterns, payload, fn
+            {pattern, replacement}, payload ->
+              String.replace(payload, ~r/#{pattern}/, replacement)
+
+            pattern, payload when is_bitstring(pattern) ->
+              String.replace(payload, ~r/#{pattern}/, @default_replacement)
           end)
         end
 

--- a/test/meta_logger/formatter_test.exs
+++ b/test/meta_logger/formatter_test.exs
@@ -22,6 +22,15 @@ defmodule MetaLogger.FormatterTest do
       assert formatted_log == ["[FILTERED]", "the world"]
     end
 
+    test "when filters given as tuples, uses given replacement instead a default one" do
+      formatted_log =
+        %{be: "good", to: ~s/{"name":"John"}/}
+        |> FormatterProtocolTest.build()
+        |> Subject.format()
+
+      assert formatted_log == ["good", ~s/{"name":"[FILTERED]"}/]
+    end
+
     test "when there is wrong struct given, raises an error" do
       defmodule WrongStruct do
         defstruct [:a]

--- a/test/support/formatter_protocol.ex
+++ b/test/support/formatter_protocol.ex
@@ -1,6 +1,11 @@
 defmodule FormatterProtocolTest do
   @moduledoc false
-  @derive {MetaLogger.Formatter, formatter_fn: &__MODULE__.format/1, filter_patterns: ["bad"]}
+  @filter_patterns [
+    "bad",
+    {~s/"name":".*"/, ~s/"name":"[FILTERED]"/}
+  ]
+  @derive {MetaLogger.Formatter,
+           formatter_fn: &__MODULE__.format/1, filter_patterns: @filter_patterns}
   defstruct [:payload]
 
   def build(my_data) do


### PR DESCRIPTION
It's possible to use custom replacement strings for patterns that need to be filtered. 